### PR TITLE
Reenable doser sensors and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The auto mode and its settings can be reset by sending the following command:
 
 ## Doser Additions (Beta)
 
-> The doser protocol and entities are **beta**. In Home Assistant, only **`chihiros.dose_ml`** is exposed right now; schedule/total-related services and sensors are intentionally disabled until they are robust across firmware variants.
+> The doser protocol and entities are **beta**. Home Assistant now exposes manual dosing, daily total sensors, and scheduling services, but firmware differences may still affect reliability. Please report any quirks you encounter.
 
 ### Supported Doser Devices
 
@@ -163,7 +163,7 @@ The auto mode and its settings can be reset by sending the following command:
 
 ### Home Assistant (Doser)
 
-* **Service (enabled):**
+* **Services:**
 
   * `chihiros.dose_ml` — one-shot manual dose on a selected channel (mL)
 
@@ -174,14 +174,13 @@ The auto mode and its settings can be reset by sending the following command:
       channel: 1       # human-friendly 1..4 (converted to wire 0..3)
       ml: 10.5         # 0.2 .. 999.9 (0.1 mL resolution)
     ```
-* **Services (currently disabled):**
+  * `chihiros.read_daily_totals` — query today’s per-channel totals and surface them in HA
+  * `chihiros.set_24h_dose` — configure a once-per-day schedule (time, days, catch-up)
 
-  * `read_daily_totals` — query “today’s per-channel totals”
-  * `set_24h_dose` — configure a once-per-day schedule (time, days, catch-up)
-* **Entities (current state):**
+* **Entities:**
 
   * Buttons/Numbers per channel for dosing operations
-  * Daily total sensors are present in code but **disabled** in the integration build
+  * Daily total sensors (per channel) reporting today’s totals in mL
 
 ### Using the CLI (Doser)
 
@@ -220,14 +219,14 @@ chihirosctl bytes-encode "5B 01 0A 00 01 22 00 00 00 00 00 00 00 00 00"
   * Params: `[ channel(0..3), 0, 0, ml_hi, ml_lo ]`
     `ml_hi = floor(ml/25.6)`, `ml_lo = round((ml - ml_hi*25.6)*10)` (0.1 mL)
 
-* **24-hour daily schedule** *(not exposed as HA service in this build)*
+* **24-hour daily schedule**
   Typical sequence observed on devices:
 
   * Time/type: `A5/0x15` → `[ ch, 1 /*24h*/, hour, minute, 0, 0 ]`
   * Amount:    `A5/0x1B` → `[ ch, weekday_mask, 1, 0, ml_hi, ml_lo ]`
   * Catch-up:  `A5/0x20` → `[ ch, 0, catch_up(0/1) ]`
 
-* **“Daily totals” query** *(sensors/services disabled in this build)*
+* **“Daily totals” query**
 
   * Query frames: LED-style `0x5B/0x22` or `0x5B/0x1E` (no params)
   * Replies include 8 params (hi/lo pairs) decoding to four per-channel mL totals.

--- a/custom_components/chihiros/chihiros_doser_control/__init__.py
+++ b/custom_components/chihiros/chihiros_doser_control/__init__.py
@@ -60,12 +60,6 @@ else:
     _LOGGER = logging.getLogger(__name__)
 
     # ────────────────────────────────────────────────────────────
-    # Feature flags (disable problematic services)
-    # ────────────────────────────────────────────────────────────
-    DISABLE_READ_DAILY_TOTALS: bool = True
-    DISABLE_SET_24H_DOSE: bool = True
-
-    # ────────────────────────────────────────────────────────────
     # Schemas
     # ────────────────────────────────────────────────────────────
     DOSE_SCHEMA = vol.Schema({
@@ -321,34 +315,30 @@ else:
         hass.services.async_register(DOMAIN, "dose_ml", _svc_dose, schema=DOSE_SCHEMA)
 
         # -------------------------
-        # Read & print daily totals — DISABLED
+        # Read & print daily totals
         # -------------------------
-        if DISABLE_READ_DAILY_TOTALS:
-            async def _svc_disabled_read(_call: ServiceCall):
-                raise HomeAssistantError("Disabled: 'read_daily_totals' is not available in this build.")
-            hass.services.async_register(DOMAIN, "read_daily_totals", _svc_disabled_read)
-        else:
-            # (Commented-out registration; preserved for later re-enable)
-            # hass.services.async_register(DOMAIN, "read_daily_totals", _svc_read_totals, schema=READ_TOTALS_SCHEMA)
-            pass
+        hass.services.async_register(
+            DOMAIN,
+            "read_daily_totals",
+            _svc_read_totals,
+            schema=READ_TOTALS_SCHEMA,
+        )
 
         # -------------------------
-        # Configure 24-hour dosing — DISABLED
+        # Configure 24-hour dosing
         # -------------------------
-        if DISABLE_SET_24H_DOSE:
-            async def _svc_disabled_set24h(_call: ServiceCall):
-                raise HomeAssistantError("Disabled: 'set_24h_dose' is not available in this build.")
-            hass.services.async_register(DOMAIN, "set_24h_dose", _svc_disabled_set24h)
-        else:
-            # (Commented-out registration; preserved for later re-enable)
-            # hass.services.async_register(DOMAIN, "set_24h_dose", _svc_set_24h, schema=SET_24H_SCHEMA)
-            pass
+        hass.services.async_register(
+            DOMAIN,
+            "set_24h_dose",
+            _svc_set_24h,
+            schema=SET_24H_SCHEMA,
+        )
 
     # ────────────────────────────────────────────────────────────
-    # ORIGINAL (kept for reference) — not registered while disabled
+    # Service handlers
     # ────────────────────────────────────────────────────────────
     async def _svc_read_totals(call: ServiceCall):
-        """Original handler retained but **not registered** while disabled."""
+        """Query the doser for the current daily totals and surface them in HA."""
         data = READ_TOTALS_SCHEMA(dict(call.data))
 
         addr = data.get("address")
@@ -433,7 +423,7 @@ else:
                     pass
 
     async def _svc_set_24h(call: ServiceCall):
-        """Original handler retained but **not registered** while disabled."""
+        """Configure a daily dosing schedule with time-of-day and weekdays."""
         data = SET_24H_SCHEMA(dict(call.data))
 
         # Resolve address

--- a/custom_components/chihiros/services.yaml
+++ b/custom_components/chihiros/services.yaml
@@ -29,106 +29,104 @@ dose_ml:
           step: 0.1
           mode: box
 
-# --- DISABLED: read_daily_totals ---
-# read_daily_totals:
-#   name: Read daily totals (mL)
-#   description: Query the doser for today's per-channel totals and print the result.
-#   fields:
-#     device_id:
-#       name: Device
-#       description: (Optional) Pick the doser device (resolves BLE address)
-#       selector:
-#         device: {}
-#     address:
-#       name: BLE address
-#       description: (Optional) Use if you don’t select a device
-#       example: "AA:BB:CC:DD:EE:FF"
+read_daily_totals:
+  name: Read daily totals (mL)
+  description: Query the doser for today's per-channel totals and print the result.
+  fields:
+    device_id:
+      name: Device
+      description: (Optional) Pick the doser device (resolves BLE address)
+      selector:
+        device: {}
+    address:
+      name: BLE address
+      description: (Optional) Use if you don’t select a device
+      example: "AA:BB:CC:DD:EE:FF"
 
-# --- DISABLED: set_24h_dose ---
-# set_24h_dose:
-#   name: Configure 24-hour dosing
-#   description: Set a daily total with a time-of-day and which days it should run.
-#   fields:
-#     device_id:
-#       name: Device
-#       description: (Optional) Pick the doser device (resolves BLE address)
-#       selector:
-#         device: {}
-#     address:
-#       name: BLE address
-#       description: (Optional) Use if you don’t select a device
-#       example: "AA:BB:CC:DD:EE:FF"
-#     channel:
-#       name: Channel
-#       required: true
-#       selector:
-#         number:
-#           min: 1
-#           max: 4
-#           step: 1
-#     daily_ml:
-#       name: Daily dose (mL)
-#       required: true
-#       selector:
-#         number:
-#           min: 0.2
-#           max: 999.9
-#           step: 0.1
-#           mode: box
-#     time:
-#       name: Time of day
-#       description: Start time for the daily dosing schedule (HH:MM, 24h).
-#       required: true
-#       selector:
-#         time: {}
-#     weekdays:
-#       name: Days (English)
-#       description: Choose the days the schedule runs. Pick "everyday" or select multiple days.
-#       required: false
-#       selector:
-#         select:
-#           multiple: true
-#           mode: list
-#           options:
-#             - everyday
-#             - monday
-#             - tuesday
-#             - wednesday
-#             - thursday
-#             - friday
-#             - saturday
-#             - sunday
-#     catch_up:
-#       name: Catch up missed doses
-#       required: false
-#       default: false
-#       selector:
-#         boolean: {}
-#     weekday_mask:
-#       name: Days bitmask (advanced)
-#       description: Alternative to the list above. 127 = Every day. If both are provided, the list of days is used.
-#       required: false
-#       default: 127
-#       selector:
-#         number:
-#           min: 0
-#           max: 127
-#           mode: box
-#     hour:
-#       name: Hour (advanced)
-#       description: Use only if you omit the Time of day field (0–23).
-#       required: false
-#       selector:
-#         number:
-#           min: 0
-#           max: 23
-#           step: 1
-#     minutes:
-#       name: Minutes (advanced)
-#       description: Use only if you omit the Time of day field (0–59).
-#       required: false
-#       selector:
-#         number:
-#           min: 0
-#           max: 59
-#           step: 1
+set_24h_dose:
+  name: Configure 24-hour dosing
+  description: Set a daily total with a time-of-day and which days it should run.
+  fields:
+    device_id:
+      name: Device
+      description: (Optional) Pick the doser device (resolves BLE address)
+      selector:
+        device: {}
+    address:
+      name: BLE address
+      description: (Optional) Use if you don’t select a device
+      example: "AA:BB:CC:DD:EE:FF"
+    channel:
+      name: Channel
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 4
+          step: 1
+    daily_ml:
+      name: Daily dose (mL)
+      required: true
+      selector:
+        number:
+          min: 0.2
+          max: 999.9
+          step: 0.1
+          mode: box
+    time:
+      name: Time of day
+      description: Start time for the daily dosing schedule (HH:MM, 24h).
+      required: true
+      selector:
+        time: {}
+    weekdays:
+      name: Days (English)
+      description: Choose the days the schedule runs. Pick "everyday" or select multiple days.
+      required: false
+      selector:
+        select:
+          multiple: true
+          mode: list
+          options:
+            - everyday
+            - monday
+            - tuesday
+            - wednesday
+            - thursday
+            - friday
+            - saturday
+            - sunday
+    catch_up:
+      name: Catch up missed doses
+      required: false
+      default: false
+      selector:
+        boolean: {}
+    weekday_mask:
+      name: Days bitmask (advanced)
+      description: Alternative to the list above. 127 = Every day. If both are provided, the list of days is used.
+      required: false
+      default: 127
+      selector:
+        number:
+          min: 0
+          max: 127
+          mode: box
+    hour:
+      name: Hour (advanced)
+      description: Use only if you omit the Time of day field (0–23).
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 23
+          step: 1
+    minutes:
+      name: Minutes (advanced)
+      description: Use only if you omit the Time of day field (0–59).
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 59
+          step: 1


### PR DESCRIPTION
## Summary
- reenable the doser daily total sensors so they update via the coordinator
- restore the read_daily_totals and set_24h_dose service registrations and YAML definitions
- refresh the README to describe the available sensors and services

## Testing
- python -m compileall custom_components/chihiros

------
https://chatgpt.com/codex/tasks/task_e_68f088c7ebf8832f99f5beb0f8a0d8d1